### PR TITLE
Яндекс Турбо Fix

### DIFF
--- a/upload/catalog/controller/extension/feed/yandex_turbo.php
+++ b/upload/catalog/controller/extension/feed/yandex_turbo.php
@@ -83,8 +83,8 @@ class ControllerExtensionFeedYandexTurbo extends Controller {
 			$output .= '<currencyId>' . $offers_currency . '</currencyId>' . $this->eol;
 			$output .= '<categoryId>' . $product['category_id'] . '</categoryId>' . $this->eol;
 			$output .= '<picture>' . $this->model_tool_image->resize($product['image'], $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_width'), $this->config->get('theme_' . $this->config->get('config_theme') . '_image_popup_height')) . '</picture>' . $this->eol;
-			$output .= '<name><![CDATA[' . $this->prepareField($product['name']) . ']]></name>' . $this->eol;
-			$output .= '<description><![CDATA[' . $this->prepareField($product['description']) . ']]></description>' . $this->eol; 
+			$output .= '<name><![CDATA[' . html_entity_decode(html_entity_decode($product['name'], ENT_QUOTES, 'UTF-8')) . ']]></name>' . $this->eol;
+			$output .= '<description><![CDATA[' . html_entity_decode(html_entity_decode($product['description'], ENT_QUOTES, 'UTF-8')) . ']]></description>' . $this->eol;
 			$output .= '</offer>' . $this->eol;
 		}
 		


### PR DESCRIPTION
Символ **&** заменяется дважды внутри тегов типо &ndash;
Т. е. сначала вместо  дефиса длинного "–" (в БД он именно так хранится) идет преобразование в &ndash;, а потом повторное преобразование & и получаем &amp;ndash;

Подробное описание проблемы: https://opencartforum.com/topic/177506-russkaya-sborka-ocstore-3037/?do=findComment&comment=1734654

Решение от автора модуля:  https://opencartforum.com/topic/177506-russkaya-sborka-ocstore-3037/?do=findComment&comment=1734660